### PR TITLE
Add Vue frontend and ASP.NET Core backend scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+.vscode/
+.DS_Store
+*.user
+*.swp
+scripts/*.bak
+**/bin/
+**/obj/

--- a/BackendApi/BackendApi.csproj
+++ b/BackendApi/BackendApi.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/BackendApi/Program.cs
+++ b/BackendApi/Program.cs
@@ -1,0 +1,22 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.MapGet("/", () => Results.Json(new { message = "API Backend funcionando" }))
+    .WithName("GetRoot")
+    .WithOpenApi();
+
+app.MapGet("/health", () => Results.Json(new { status = "Healthy" }))
+    .WithName("GetHealth")
+    .WithOpenApi();
+
+app.Run();

--- a/BackendApi/Properties/launchSettings.json
+++ b/BackendApi/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "BackendApi": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7164;http://localhost:5186",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/BackendApi/appsettings.json
+++ b/BackendApi/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/frontend/env.d.ts
+++ b/frontend/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Frontend</title>
+  </head>
+  <body class="bg-slate-900 text-slate-100">
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@vitejs/plugin-vue": "^5.0.0",
+    "autoprefixer": "^10.0.0",
+    "postcss": "^8.0.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "vue-tsc": "^2.0.0"
+  }
+}

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import HelloWorld from './components/HelloWorld.vue';
+</script>
+
+<template>
+  <main class="min-h-screen bg-slate-900 text-slate-100">
+    <section class="mx-auto flex max-w-4xl flex-col gap-6 px-6 py-16 text-center">
+      <h1 class="text-4xl font-bold tracking-tight sm:text-5xl">
+        ¡Bienvenido a tu proyecto Vue 3 + TypeScript + Tailwind!
+      </h1>
+      <p class="text-lg text-slate-300">
+        Personaliza esta plantilla para comenzar a construir tu aplicación.
+      </p>
+      <HelloWorld msg="Comienza a editar en src/components/HelloWorld.vue" />
+    </section>
+  </main>
+</template>

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1,0 +1,8 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}

--- a/frontend/src/components/HelloWorld.vue
+++ b/frontend/src/components/HelloWorld.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+interface Props {
+  msg: string;
+}
+
+const props = defineProps<Props>();
+</script>
+
+<template>
+  <div class="rounded-lg border border-slate-700 bg-slate-800 p-6 text-left shadow-lg">
+    <h2 class="mb-2 text-2xl font-semibold text-slate-100">{{ props.msg }}</h2>
+    <p class="text-slate-300">
+      Edita <code class="font-mono text-slate-200">components/HelloWorld.vue</code> para comenzar.
+    </p>
+  </div>
+</template>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,8 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+import './assets/main.css';
+
+const app = createApp(App);
+
+app.mount('#app');

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{vue,ts,js,tsx,jsx}'],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "lib": ["ESNext", "DOM"],
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["vite.config.ts", "env.d.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': '/src'
+    }
+  }
+});

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,3 @@
+# Scripts de base de datos
+
+Coloca aquí los scripts de SQL Server (MSSQL) relacionados con el proyecto.


### PR DESCRIPTION
## Summary
- scaffold a Vue 3 + TypeScript + Tailwind frontend project configured with Vite
- add an ASP.NET Core minimal API backend project targeting .NET 8
- create a scripts directory for future MSSQL database scripts and repository ignore rules

## Testing
- npm install *(fails: npm registry access is forbidden in this environment)*
- dotnet build BackendApi *(fails: dotnet CLI is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dec737d71083208b705746db66a556